### PR TITLE
Add R2 jurisdiction support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.5.3 (2026-04-28)
+
+### Features
+
+- **r2**: Add optional R2 jurisdiction support via `jurisdiction` or
+  `R2_JURISDICTION`, enabling jurisdictional bucket endpoints such as EU R2
+  buckets. Thanks @FleetAdmiralJakob for the report and initial patch.
+
+---
+
 ## 0.5.2 (2026-03-20)
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ import { FilesControl } from "@gilhrpenner/convex-files-control";
 import { components } from "./_generated/api";
 
 const files = new FilesControl(components.convexFilesControl, {
-  // r2: { accountId, accessKeyId, secretAccessKey, bucketName },
+  // r2: { accountId, accessKeyId, secretAccessKey, bucketName, jurisdiction },
 });
 
 await files.generateUploadUrl(ctx, { provider: "convex" });
@@ -351,6 +351,7 @@ the HTTP routes:
 - `R2_ACCESS_KEY_ID`
 - `R2_SECRET_ACCESS_KEY`
 - `R2_BUCKET_NAME`
+- `R2_JURISDICTION` (optional, for example `eu` or `fedramp`)
 
 ## Transfer between providers
 

--- a/README.md
+++ b/README.md
@@ -353,6 +353,11 @@ the HTTP routes:
 - `R2_BUCKET_NAME`
 - `R2_JURISDICTION` (optional, for example `eu` or `fedramp`)
 
+Set `R2_JURISDICTION` only when your bucket was created with a Cloudflare R2
+jurisdiction. See Cloudflare's
+[data location docs](https://developers.cloudflare.com/r2/reference/data-location/#using-jurisdictions-with-the-s3-api)
+for the supported jurisdiction values and S3 endpoint format.
+
 ## Transfer between providers
 
 ```ts

--- a/example/convex/r2Config.ts
+++ b/example/convex/r2Config.ts
@@ -3,6 +3,7 @@ export function getR2ConfigFromEnv() {
   const accessKeyId = process.env.R2_ACCESS_KEY_ID;
   const secretAccessKey = process.env.R2_SECRET_ACCESS_KEY;
   const bucketName = process.env.R2_BUCKET_NAME;
+  const jurisdiction = process.env.R2_JURISDICTION;
 
   if (!accountId || !accessKeyId || !secretAccessKey || !bucketName) {
     return null;
@@ -13,5 +14,6 @@ export function getR2ConfigFromEnv() {
     accessKeyId,
     secretAccessKey,
     bucketName,
+    jurisdiction,
   };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gilhrpenner/convex-files-control",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gilhrpenner/convex-files-control",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "bugs": {
     "url": "https://github.com/gilhrpenner/convex-files-control/issues"
   },
-  "version": "0.5.2",
+  "version": "0.5.3",
   "publishConfig": {
     "access": "public"
   },

--- a/src/__tests__/client-extra.test.ts
+++ b/src/__tests__/client-extra.test.ts
@@ -220,6 +220,7 @@ describe("registerRoutes extra coverage", () => {
     process.env.R2_ACCESS_KEY_ID = "access";
     process.env.R2_SECRET_ACCESS_KEY = "secret";
     process.env.R2_BUCKET_NAME = "bucket";
+    process.env.R2_JURISDICTION = "eu";
 
     const router = createRouter();
     registerRoutes(router, component, {
@@ -253,6 +254,7 @@ describe("registerRoutes extra coverage", () => {
           accessKeyId: "access",
           secretAccessKey: "secret",
           bucketName: "bucket",
+          jurisdiction: "eu",
         },
       },
     );
@@ -261,6 +263,7 @@ describe("registerRoutes extra coverage", () => {
     delete process.env.R2_ACCESS_KEY_ID;
     delete process.env.R2_SECRET_ACCESS_KEY;
     delete process.env.R2_BUCKET_NAME;
+    delete process.env.R2_JURISDICTION;
   });
 
   test("upload route rejects invalid checkUploadRequest results", async () => {
@@ -784,6 +787,36 @@ describe("FilesControl class and clientApi", () => {
       filesPartial.generateUploadUrl(ctx, { provider: "r2" }),
     ).rejects.toThrow(
       "R2 configuration is missing required fields for R2 uploads. Missing: R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_BUCKET_NAME",
+    );
+  });
+
+  test("FilesControl treats R2 jurisdiction as optional", async () => {
+    const runMutation = buildMutationMocks();
+    const runAction = buildActionMocks();
+    const runQuery = buildQueryMocks();
+    const ctx = makeCtx(runMutation, runQuery, runAction);
+
+    const files = new FilesControl(component, {
+      r2: {
+        accountId: "acct",
+        accessKeyId: "access",
+        secretAccessKey: "secret",
+        bucketName: "bucket",
+      },
+    });
+
+    await files.generateUploadUrl(ctx, { provider: "r2" });
+
+    expect(runMutation).toHaveBeenCalledWith(
+      component.upload.generateUploadUrl,
+      expect.objectContaining({
+        r2Config: {
+          accountId: "acct",
+          accessKeyId: "access",
+          secretAccessKey: "secret",
+          bucketName: "bucket",
+        },
+      }),
     );
   });
 

--- a/src/__tests__/r2.test.ts
+++ b/src/__tests__/r2.test.ts
@@ -66,6 +66,9 @@ describe("shared r2 endpoint", () => {
     expect(r2EndpointFromAccountId("acct")).toBe(
       "https://acct.r2.cloudflarestorage.com",
     );
+    expect(r2EndpointFromAccountId("acct", " EU ")).toBe(
+      "https://acct.eu.r2.cloudflarestorage.com",
+    );
   });
 });
 
@@ -97,6 +100,19 @@ describe("component r2 helpers", () => {
       accessKeyId: "access",
       secretAccessKey: "secret",
     });
+    expect((client as any).config.forcePathStyle).toBe(false);
+  });
+
+  test("createR2Client configures jurisdiction endpoint with path-style URLs", () => {
+    const client = createR2Client({
+      ...config,
+      jurisdiction: "eu",
+    }) as unknown as S3Client;
+
+    expect((client as any).config.endpoint).toBe(
+      "https://acct.eu.r2.cloudflarestorage.com",
+    );
+    expect((client as any).config.forcePathStyle).toBe(true);
   });
 
   test("getR2UploadUrl and getR2DownloadUrl use signed urls", async () => {

--- a/src/__tests__/shared.test.ts
+++ b/src/__tests__/shared.test.ts
@@ -36,6 +36,9 @@ describe("shared helpers", () => {
     expect(r2EndpointFromAccountId("abc123")).toBe(
       "https://abc123.r2.cloudflarestorage.com",
     );
+    expect(r2EndpointFromAccountId("abc123", "FEDRAMP")).toBe(
+      "https://abc123.fedramp.r2.cloudflarestorage.com",
+    );
   });
 
   test("isStorageProvider validates providers", () => {

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -55,29 +55,41 @@ export type R2ConfigInput = {
   accessKeyId?: string;
   secretAccessKey?: string;
   bucketName?: string;
+  jurisdiction?: string;
 };
 
-const R2_ENV_VARS: Record<keyof R2Config, string> = {
+const REQUIRED_R2_ENV_VARS = {
   accountId: "R2_ACCOUNT_ID",
   accessKeyId: "R2_ACCESS_KEY_ID",
   secretAccessKey: "R2_SECRET_ACCESS_KEY",
   bucketName: "R2_BUCKET_NAME",
-};
+} satisfies Record<keyof Omit<R2Config, "jurisdiction">, string>;
+
+const OPTIONAL_R2_ENV_VARS = {
+  jurisdiction: "R2_JURISDICTION",
+} satisfies Record<"jurisdiction", string>;
 
 const readEnv = (key: string) =>
   typeof process !== "undefined" ? process.env[key] : undefined;
 
 const resolveR2Config = (input?: R2ConfigInput): R2Config | null => {
   const config = {
-    accountId: input?.accountId ?? readEnv(R2_ENV_VARS.accountId),
-    accessKeyId: input?.accessKeyId ?? readEnv(R2_ENV_VARS.accessKeyId),
+    accountId: input?.accountId ?? readEnv(REQUIRED_R2_ENV_VARS.accountId),
+    accessKeyId:
+      input?.accessKeyId ?? readEnv(REQUIRED_R2_ENV_VARS.accessKeyId),
     secretAccessKey:
-      input?.secretAccessKey ?? readEnv(R2_ENV_VARS.secretAccessKey),
-    bucketName: input?.bucketName ?? readEnv(R2_ENV_VARS.bucketName),
+      input?.secretAccessKey ??
+      readEnv(REQUIRED_R2_ENV_VARS.secretAccessKey),
+    bucketName: input?.bucketName ?? readEnv(REQUIRED_R2_ENV_VARS.bucketName),
+    jurisdiction:
+      input?.jurisdiction ?? readEnv(OPTIONAL_R2_ENV_VARS.jurisdiction),
   };
 
-  const hasAll = Object.values(config).every((value) => Boolean(value));
-  if (!hasAll) {
+  const hasAllRequired = Object.keys(REQUIRED_R2_ENV_VARS).every((key) => {
+    const field = key as keyof typeof REQUIRED_R2_ENV_VARS;
+    return Boolean(config[field]);
+  });
+  if (!hasAllRequired) {
     return null;
   }
 
@@ -90,10 +102,10 @@ const requireR2Config = (input?: R2ConfigInput, context?: string): R2Config => {
     return config;
   }
 
-  const missing = Object.entries(R2_ENV_VARS)
+  const missing = Object.entries(REQUIRED_R2_ENV_VARS)
     .filter(([key]) => {
-      const field = key as keyof R2Config;
-      const value = input?.[field] ?? readEnv(R2_ENV_VARS[field]);
+      const field = key as keyof typeof REQUIRED_R2_ENV_VARS;
+      const value = input?.[field] ?? readEnv(REQUIRED_R2_ENV_VARS[field]);
       return !value;
     })
     .map(([, envVar]) => envVar);

--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -56,6 +56,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
             accessKeyId: string;
             accountId: string;
             bucketName: string;
+            jurisdiction?: string;
             secretAccessKey: string;
           };
         },
@@ -70,6 +71,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
             accessKeyId: string;
             accountId: string;
             bucketName: string;
+            jurisdiction?: string;
             secretAccessKey: string;
           };
           storageId: string;
@@ -85,6 +87,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
             accessKeyId: string;
             accountId: string;
             bucketName: string;
+            jurisdiction?: string;
             secretAccessKey: string;
           };
           storageId: string;
@@ -106,6 +109,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
             accessKeyId: string;
             accountId: string;
             bucketName: string;
+            jurisdiction?: string;
             secretAccessKey: string;
           };
         },
@@ -297,6 +301,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
             accessKeyId: string;
             accountId: string;
             bucketName: string;
+            jurisdiction?: string;
             secretAccessKey: string;
           };
           storageId: string;
@@ -320,6 +325,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
             accessKeyId: string;
             accountId: string;
             bucketName: string;
+            jurisdiction?: string;
             secretAccessKey: string;
           };
           storageId: string;
@@ -370,6 +376,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
             accessKeyId: string;
             accountId: string;
             bucketName: string;
+            jurisdiction?: string;
             secretAccessKey: string;
           };
           virtualPath?: string;

--- a/src/component/r2.ts
+++ b/src/component/r2.ts
@@ -14,6 +14,7 @@ export const r2ConfigValidator = v.object({
   accessKeyId: v.string(),
   secretAccessKey: v.string(),
   bucketName: v.string(),
+  jurisdiction: v.optional(v.string()),
 });
 
 export function requireR2Config(
@@ -30,7 +31,8 @@ export function requireR2Config(
 export function createR2Client(config: R2Config) {
   return new S3Client({
     region: "auto",
-    endpoint: r2EndpointFromAccountId(config.accountId),
+    endpoint: r2EndpointFromAccountId(config.accountId, config.jurisdiction),
+    forcePathStyle: Boolean(config.jurisdiction?.trim()),
     credentials: {
       accessKeyId: config.accessKeyId,
       secretAccessKey: config.secretAccessKey,

--- a/src/shared/r2.ts
+++ b/src/shared/r2.ts
@@ -1,3 +1,10 @@
-export function r2EndpointFromAccountId(accountId: string) {
-  return `https://${accountId}.r2.cloudflarestorage.com`;
+export function r2EndpointFromAccountId(
+  accountId: string,
+  jurisdiction?: string,
+) {
+  const normalizedJurisdiction = jurisdiction?.trim().toLowerCase();
+  const jurisdictionSegment = normalizedJurisdiction
+    ? `.${normalizedJurisdiction}`
+    : "";
+  return `https://${accountId}${jurisdictionSegment}.r2.cloudflarestorage.com`;
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -5,6 +5,7 @@ export type R2Config = {
   accessKeyId: string;
   secretAccessKey: string;
   bucketName: string;
+  jurisdiction?: string;
 };
 
 export type UploadMetadata = {


### PR DESCRIPTION
## Summary

Adds optional Cloudflare R2 jurisdiction support for buckets created with jurisdictional restrictions, such as EU R2 buckets.

- adds `jurisdiction?: string` to R2 config inputs and component validators
- reads optional `R2_JURISDICTION` from env without making it a required R2 setting
- builds jurisdiction-aware R2 S3 endpoints like `https://<account>.eu.r2.cloudflarestorage.com`
- enables path-style addressing when a jurisdiction is set
- bumps the package version to `0.5.3`

Thanks @FleetAdmiralJakob for the report and initial patch.

## Validation

- `npm run build`
- `npm run typecheck:all`
- `npm run lint`
- `npm run test`