### PR TITLE
Fix Convex action context type compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.5.6 (2026-06-12)
+
+### Fixes
+
+- **types**: Accept Convex action contexts in `FilesControl` query and mutation
+  helpers with Convex 1.41.0 by typing helper contexts against the shared
+  action `runQuery`/`runMutation` signatures.
+- **tests**: Add server context type coverage and bump the Convex dev dependency
+  to 1.41.0 so local checks exercise the updated Convex ctx signatures.
+
+---
+
 ## 0.5.5 (2026-06-02)
 
 ### Chores

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gilhrpenner/convex-files-control",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gilhrpenner/convex-files-control",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",
@@ -26,7 +26,7 @@
         "@vitejs/plugin-react": "^5.2.0",
         "@vitest/coverage-v8": "^4.1.7",
         "chokidar-cli": "3.0.0",
-        "convex": "1.40.0",
+        "convex": "1.41.0",
         "convex-test": "0.0.53",
         "cpy-cli": "^6.0.0",
         "eslint": "9.39.2",
@@ -3922,9 +3922,9 @@
       "license": "MIT"
     },
     "node_modules/convex": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/convex/-/convex-1.40.0.tgz",
-      "integrity": "sha512-jChWEB45q+9Ibryc7hg0l6hB1xA4zwE2y6ZhkhGP6oJkqYeiURkMagA2ZQZYMy1/T8PZ9ztoVJJtbL/+Ob851Q==",
+      "version": "1.41.0",
+      "resolved": "https://registry.npmjs.org/convex/-/convex-1.41.0.tgz",
+      "integrity": "sha512-euxVf6yfpB7/VGKOobkLgjpbJidsUgW+b0ezonEyCUPqlpHFwR4/yIiI1hjjErzraiw91GxrtxpXQClMLNqU+w==",
       "license": "Apache-2.0",
       "dependencies": {
         "esbuild": "0.27.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "bugs": {
     "url": "https://github.com/gilhrpenner/convex-files-control/issues"
   },
-  "version": "0.5.5",
+  "version": "0.5.6",
   "publishConfig": {
     "access": "public"
   },
@@ -104,7 +104,7 @@
     "@vitejs/plugin-react": "^5.2.0",
     "@vitest/coverage-v8": "^4.1.7",
     "chokidar-cli": "3.0.0",
-    "convex": "1.40.0",
+    "convex": "1.41.0",
     "convex-test": "0.0.53",
     "cpy-cli": "^6.0.0",
     "eslint": "9.39.2",

--- a/src/__tests__/client-types.test.ts
+++ b/src/__tests__/client-types.test.ts
@@ -1,0 +1,27 @@
+import { test } from "vitest";
+import type {
+  GenericActionCtx,
+  GenericDataModel,
+  GenericMutationCtx,
+  GenericQueryCtx,
+} from "convex/server";
+import { FilesControl } from "../client/index.js";
+
+function assertFilesControlServerCtxTypes(
+  actionCtx: GenericActionCtx<GenericDataModel>,
+  mutationCtx: GenericMutationCtx<GenericDataModel>,
+  queryCtx: GenericQueryCtx<GenericDataModel>,
+) {
+  const files = new FilesControl({} as never);
+
+  void files.finalizeUpload(actionCtx, {} as never);
+  void files.finalizeUpload(mutationCtx, {} as never);
+
+  void files.getFile(actionCtx, { storageId: "storage-id" });
+  void files.getFile(mutationCtx, { storageId: "storage-id" });
+  void files.getFile(queryCtx, { storageId: "storage-id" });
+}
+
+test("FilesControl helper methods accept server contexts", () => {
+  void assertFilesControlServerCtxTypes;
+});

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -624,11 +624,11 @@ export type ClientApi = ApiFromModules<{
 }>["client"];
 
 type RunQueryCtx = {
-  runQuery: GenericQueryCtx<GenericDataModel>["runQuery"];
+  runQuery: GenericActionCtx<GenericDataModel>["runQuery"];
 };
 
 type RunMutationCtx = {
-  runMutation: GenericMutationCtx<GenericDataModel>["runMutation"];
+  runMutation: GenericActionCtx<GenericDataModel>["runMutation"];
 };
 
 type RunActionCtx = {


### PR DESCRIPTION
## Summary

- Fix `FilesControl` query and mutation helper ctx types so Convex action contexts are accepted with Convex 1.41.0.
- Add type coverage for action, mutation, and query contexts against the helper methods.
- Bump the package to 0.5.6 and document the fix in the changelog.

## Root Cause

Convex 1.41.0 widened `GenericQueryCtx` and `GenericMutationCtx` `runQuery`/`runMutation` signatures with transaction options, while `GenericActionCtx` kept the narrower no-options call shape. `FilesControl` only uses the shared two-argument form, so deriving helper ctx types from query/mutation contexts rejected valid action contexts.

Fixes #17.

## Validation

- `npm run typecheck`
- `npm run test`
- `npm run build`
- `npm run lint`
- Packed `0.5.6` locally and verified the original Convex 1.41.0 temp repro compiles with no TypeScript errors.