### PR TITLE
Allow retaining host-owned storage during deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.5.7 (2026-08-02)
+
+### Features
+
+- **cleanup**: Allow callers with host-owned blob lifecycles to pass
+  `deleteStorage: false` when deleting a file, removing the component's file
+  registration, access rows, and download grants while retaining the underlying
+  Convex or R2 storage object. Thanks @seanaguinaga for the contribution.
+
+### Tests
+
+- **cleanup**: Cover retained Convex and R2 storage while verifying related
+  component records are removed.
+
+### Chores
+
+- **deps**: Refresh `js-yaml`, `postcss`, and the example app's `@auth/core`
+  dependency through Dependabot updates.
+
+---
+
 ## 0.5.6 (2026-06-12)
 
 ### Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gilhrpenner/convex-files-control",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gilhrpenner/convex-files-control",
-      "version": "0.5.6",
+      "version": "0.5.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "bugs": {
     "url": "https://github.com/gilhrpenner/convex-files-control/issues"
   },
-  "version": "0.5.6",
+  "version": "0.5.7",
   "publishConfig": {
     "access": "public"
   },

--- a/src/__tests__/client-extra.test.ts
+++ b/src/__tests__/client-extra.test.ts
@@ -672,6 +672,20 @@ describe("FilesControl class and clientApi", () => {
     );
 
     await files.deleteFile(ctx, { storageId: "storage" });
+    expect(runMutation).toHaveBeenCalledWith(component.cleanUp.deleteFile, {
+      deleteStorage: undefined,
+      storageId: "storage",
+      r2Config,
+    });
+    await files.deleteFile(ctx, {
+      storageId: "storage",
+      deleteStorage: false,
+    });
+    expect(runMutation).toHaveBeenCalledWith(component.cleanUp.deleteFile, {
+      deleteStorage: false,
+      storageId: "storage",
+      r2Config,
+    });
     await files.deleteFile(ctx, { storageId: "storage", r2Config });
     await files.cleanupExpired(ctx, { limit: 5 });
     await files.cleanupExpired(ctx, {});

--- a/src/__tests__/component.test.ts
+++ b/src/__tests__/component.test.ts
@@ -1043,6 +1043,46 @@ describe("cleanUp", () => {
     expect(r2Spy).toHaveBeenCalledWith(r2Config, storageId);
   });
 
+  test("deleteFile retains host-owned r2 storage and removes records", async () => {
+    const t = initConvexTest();
+    const storageId = "r2-retain";
+    const fileId = await insertFileRecord(t, storageId, undefined, "r2");
+    await insertFileAccess(t, fileId, storageId, "key");
+    await insertDownloadGrant(t, {
+      storageId,
+      maxUses: null,
+      useCount: 0,
+    });
+
+    const r2Spy = vi.spyOn(r2, "deleteR2Object").mockResolvedValue(undefined);
+    r2Spy.mockClear();
+
+    expect(
+      await t.mutation(api.cleanUp.deleteFile, {
+        storageId,
+        deleteStorage: false,
+      }),
+    ).toEqual({ deleted: true });
+    expect(r2Spy).not.toHaveBeenCalled();
+
+    const remaining = await t.run(async (ctx) => ({
+      file: await ctx.db
+        .query("files")
+        .withIndex("by_storageId", (q) => q.eq("storageId", storageId))
+        .unique(),
+      accessRows: await ctx.db
+        .query("fileAccess")
+        .withIndex("by_storageId", (q) => q.eq("storageId", storageId))
+        .collect(),
+      grants: await ctx.db
+        .query("downloadGrants")
+        .withIndex("by_storageId", (q) => q.eq("storageId", storageId))
+        .collect(),
+    }));
+
+    expect(remaining).toEqual({ file: null, accessRows: [], grants: [] });
+  });
+
   test("cleanupExpired deletes expired records", async () => {
     const t = initConvexTest();
     vi.useFakeTimers();

--- a/src/__tests__/component.test.ts
+++ b/src/__tests__/component.test.ts
@@ -963,6 +963,29 @@ describe("cleanUp", () => {
     });
 
     expect(deleted).toEqual({ deleted: true });
+
+    const { storageId: retainedStorage } = await createStorageFile(
+      t,
+      "retain-storage",
+    );
+    await t.mutation(api.upload.registerFile, {
+      storageId: retainedStorage,
+      storageProvider: "convex",
+      accessKeys: ["k"],
+    });
+
+    expect(
+      await t.mutation(api.cleanUp.deleteFile, {
+        storageId: retainedStorage,
+        deleteStorage: false,
+      }),
+    ).toEqual({ deleted: true });
+    expect(
+      await t.run(async (ctx) => await ctx.storage.getUrl(retainedStorage)),
+    ).toBeTypeOf("string");
+    expect(
+      await t.query(api.queries.getFile, { storageId: retainedStorage }),
+    ).toBeNull();
   });
 
   test("deleteStorageFile action deletes convex and r2", async () => {

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -896,9 +896,14 @@ export class FilesControl {
 
   async deleteFile(
     ctx: RunMutationCtx,
-    args: { storageId: string; r2Config?: R2Config },
+    args: {
+      storageId: string;
+      deleteStorage?: boolean;
+      r2Config?: R2Config;
+    },
   ) {
     return ctx.runMutation(this.component.cleanUp.deleteFile, {
+      deleteStorage: args.deleteStorage,
       storageId: args.storageId,
       r2Config: this.maybeR2Config(args.r2Config),
     });

--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -67,6 +67,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         "mutation",
         "internal",
         {
+          deleteStorage?: boolean;
           r2Config?: {
             accessKeyId: string;
             accountId: string;

--- a/src/component/cleanUp.ts
+++ b/src/component/cleanUp.ts
@@ -88,6 +88,7 @@ async function deleteFileCascadeCore(
     secretAccessKey: string;
     bucketName: string;
   },
+  deleteStorage = true,
 ) {
   const storageId = file.storageId;
   const [accessRows, grants] = await Promise.all([
@@ -103,11 +104,12 @@ async function deleteFileCascadeCore(
 
   await Promise.all([
     ctx.db.delete(file._id),
-    deleteStorageFileWithRetry(ctx, {
-      storageId,
-      storageProvider: file.storageProvider,
-      r2Config,
-    }),
+    deleteStorage &&
+      deleteStorageFileWithRetry(ctx, {
+        storageId,
+        storageProvider: file.storageProvider,
+        r2Config,
+      }),
     ...accessRows.map((row) => ctx.db.delete(row._id)),
     ...grants.map((grant) => ctx.db.delete(grant._id)),
   ]);
@@ -137,6 +139,7 @@ export async function deleteFileCascade(
  * Removes access key mappings, download grants, and the storage object.
  *
  * @param args.storageId - The file's storage ID.
+ * @param args.deleteStorage - Whether the component also owns and deletes the storage object.
  * @returns `{ deleted: true }` if the file existed and was removed.
  *
  * @example
@@ -148,6 +151,7 @@ export async function deleteFileCascade(
  */
 export const deleteFile = mutation({
   args: {
+    deleteStorage: v.optional(v.boolean()),
     storageId: v.string(),
     r2Config: v.optional(r2ConfigValidator),
   },
@@ -160,7 +164,12 @@ export const deleteFile = mutation({
       return { deleted: false };
     }
 
-    await deleteFileCascadeCore(ctx, file, args.r2Config);
+    await deleteFileCascadeCore(
+      ctx,
+      file,
+      args.r2Config,
+      args.deleteStorage ?? true,
+    );
     return { deleted: true };
   },
 });


### PR DESCRIPTION
Adds an optional `deleteStorage` flag to the component cleanup mutation and server helper. It defaults to `true`, preserving existing behavior.

Callers that own the blob lifecycle can pass `false` to atomically remove the file registration, access rows, and download grants before deleting storage in their own transaction.

Validation: `npm run check` (151 tests).
