### PR TITLE
feat: add exact HTTP route CORS policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.5.8 (2026-08-25)
+
+### Features
+
+- **http**: Add an optional exact CORS policy for HTTP upload and download
+  routes. Applications can allow specific browser origins and request headers,
+  control credential support, and reject other browser origins with `403`.
+  Routes keep the existing permissive behavior when the policy is omitted.
+
+### Tests
+
+- **http**: Cover allowed and rejected origins, exact allowed-header lists, and
+  credential response headers.
+
+---
+
 ## 0.5.7 (2026-08-02)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ registerRoutes(http, components.convexFilesControl, {
     const fileName =
       typeof fileNameFromForm === "string"
         ? fileNameFromForm
-        : (file as File).name ?? "untitled";
+        : ((file as File).name ?? "untitled");
     // await ctx.runMutation(api.files.recordUpload, { ...result, fileName });
   },
 
@@ -160,8 +160,8 @@ HTTP upload requires `multipart/form-data` with fields:
 - `expiresAt` (optional, timestamp or `null`)
 
 Access keys are not accepted via the form; they must come from
-`checkUploadRequest`. Additional form fields are available on
-`onUploadComplete` via `formData`.
+`checkUploadRequest`. Additional form fields are available on `onUploadComplete`
+via `formData`.
 
 Useful route options:
 
@@ -170,6 +170,21 @@ Useful route options:
 - `enableDownloadRoute` (default: `true`)
 - `requireAccessKey` (force `checkDownloadRequest` to return an access key)
 - `passwordHeader` / `passwordQueryParam` (override or disable password inputs)
+- `cors` (exact browser origins and allowed headers; other browser origins
+  receive `403`)
+
+```ts
+registerRoutes(http, components.convexFilesControl, {
+  cors: {
+    allowedOrigins: ["https://app.example.com"],
+    allowedHeaders: ["Authorization", "Content-Type"],
+    allowCredentials: false,
+  },
+});
+```
+
+Requests without an `Origin` header continue to work. If `cors` is omitted, the
+existing permissive CORS behavior remains unchanged.
 
 ## Uploading files
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gilhrpenner/convex-files-control",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gilhrpenner/convex-files-control",
-      "version": "0.5.7",
+      "version": "0.5.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "bugs": {
     "url": "https://github.com/gilhrpenner/convex-files-control/issues"
   },
-  "version": "0.5.7",
+  "version": "0.5.8",
   "publishConfig": {
     "access": "public"
   },

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -132,6 +132,72 @@ describe("registerRoutes", () => {
     expect(downloadResponse.status).toBe(204);
   });
 
+  test("applies an exact CORS policy to preflight and normal requests", async () => {
+    const router = createRouter();
+    registerRoutes(router, component, {
+      cors: {
+        allowedHeaders: ["Authorization", "Content-Type"],
+        allowedOrigins: ["https://app.example.com"],
+        allowCredentials: false,
+      },
+      enableUploadRoute: true,
+      checkUploadRequest: mockCheckUploadRequest(),
+    });
+
+    const uploadOptions = getRoute(router, "/files/upload", "OPTIONS");
+    const uploadPost = getRoute(router, "/files/upload", "POST");
+    const optionsHandler = getHandler(uploadOptions.handler);
+    const postHandler = getHandler(uploadPost.handler);
+    const allowedRequest = new Request("https://api.example.com/files/upload", {
+      headers: {
+        "Access-Control-Request-Headers": "Authorization,X-Injected-Header",
+        Origin: "https://app.example.com",
+      },
+      method: "OPTIONS",
+    });
+    const blockedRequest = new Request("https://api.example.com/files/upload", {
+      headers: { Origin: "https://preview.example.com" },
+      method: "OPTIONS",
+    });
+    const blockedPostRequest = new Request(
+      "https://api.example.com/files/upload",
+      {
+        body: "{}",
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "https://preview.example.com",
+        },
+        method: "POST",
+      },
+    );
+
+    const allowedResponse = await optionsHandler({}, allowedRequest);
+    const blockedResponse = await optionsHandler({}, blockedRequest);
+    const blockedPostResponse = await postHandler(
+      makeCtx(),
+      blockedPostRequest,
+    );
+
+    expect(allowedResponse.status).toBe(204);
+    expect(allowedResponse.headers.get("Access-Control-Allow-Origin")).toBe(
+      "https://app.example.com",
+    );
+    expect(allowedResponse.headers.get("Access-Control-Allow-Headers")).toBe(
+      "Content-Type, Authorization",
+    );
+    expect(
+      allowedResponse.headers.get("Access-Control-Allow-Credentials"),
+    ).toBeNull();
+    expect(blockedResponse.status).toBe(403);
+    expect(
+      blockedResponse.headers.get("Access-Control-Allow-Origin"),
+    ).toBeNull();
+    expect(blockedPostResponse.status).toBe(403);
+    expect(
+      blockedPostResponse.headers.get("Access-Control-Allow-Origin"),
+    ).toBeNull();
+  });
+
   test("download route handles without accessKeyQueryParam", async () => {
     const router = createRouter();
     registerRoutes(router, component);

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -136,7 +136,7 @@ describe("registerRoutes", () => {
     const router = createRouter();
     registerRoutes(router, component, {
       cors: {
-        allowedHeaders: ["Authorization", "Content-Type"],
+        allowedHeaders: ["X-Trace"],
         allowedOrigins: ["https://app.example.com"],
         allowCredentials: false,
       },
@@ -150,7 +150,7 @@ describe("registerRoutes", () => {
     const postHandler = getHandler(uploadPost.handler);
     const allowedRequest = new Request("https://api.example.com/files/upload", {
       headers: {
-        "Access-Control-Request-Headers": "Authorization,X-Injected-Header",
+        "Access-Control-Request-Headers": "X-Trace,X-Injected-Header",
         Origin: "https://app.example.com",
       },
       method: "OPTIONS",
@@ -183,7 +183,7 @@ describe("registerRoutes", () => {
       "https://app.example.com",
     );
     expect(allowedResponse.headers.get("Access-Control-Allow-Headers")).toBe(
-      "Content-Type, Authorization",
+      "X-Trace",
     );
     expect(
       allowedResponse.headers.get("Access-Control-Allow-Credentials"),

--- a/src/client/http.ts
+++ b/src/client/http.ts
@@ -6,7 +6,7 @@ export interface CorsPolicy {
   allowCredentials?: boolean;
 }
 
-function buildAllowHeaders(extra?: string[]): string {
+function buildAllowHeaders(extra?: string[], includeDefaults = true): string {
   const headers: string[] = [];
   const seen = new Set<string>();
 
@@ -19,8 +19,10 @@ function buildAllowHeaders(extra?: string[]): string {
     headers.push(trimmed);
   };
 
-  for (const header of DEFAULT_ALLOW_HEADERS) {
-    addHeader(header);
+  if (includeDefaults) {
+    for (const header of DEFAULT_ALLOW_HEADERS) {
+      addHeader(header);
+    }
   }
   for (const header of extra ?? []) {
     addHeader(header);
@@ -37,7 +39,7 @@ export function corsHeaders(
   const headers = new Headers({
     "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
     "Access-Control-Allow-Headers": policy
-      ? buildAllowHeaders(policy.allowedHeaders)
+      ? buildAllowHeaders(policy.allowedHeaders, false)
       : buildAllowHeaders(allowHeaders),
   });
 

--- a/src/client/http.ts
+++ b/src/client/http.ts
@@ -1,5 +1,11 @@
 const DEFAULT_ALLOW_HEADERS = ["Content-Type", "Authorization"];
 
+export interface CorsPolicy {
+  allowedHeaders: string[];
+  allowedOrigins: string[];
+  allowCredentials?: boolean;
+}
+
 function buildAllowHeaders(extra?: string[]): string {
   const headers: string[] = [];
   const seen = new Set<string>();
@@ -23,22 +29,38 @@ function buildAllowHeaders(extra?: string[]): string {
   return headers.join(", ");
 }
 
-export function corsHeaders(origin?: string, allowHeaders?: string[]): Headers {
+export function corsHeaders(
+  origin?: string,
+  allowHeaders?: string[],
+  policy?: CorsPolicy,
+): Headers {
   const headers = new Headers({
-    "Access-Control-Allow-Origin": origin || "*",
     "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-    "Access-Control-Allow-Headers": buildAllowHeaders(allowHeaders),
+    "Access-Control-Allow-Headers": policy
+      ? buildAllowHeaders(policy.allowedHeaders)
+      : buildAllowHeaders(allowHeaders),
   });
+
   if (origin) {
+    headers.set("Access-Control-Allow-Origin", origin);
+  } else if (!policy) {
+    headers.set("Access-Control-Allow-Origin", "*");
+  }
+
+  if (origin && (policy?.allowCredentials ?? !policy)) {
     headers.set("Access-Control-Allow-Credentials", "true");
   }
   return headers;
 }
 
-export function corsResponse(origin?: string, allowHeaders?: string[]): Response {
+export function corsResponse(
+  origin?: string,
+  allowHeaders?: string[],
+  policy?: CorsPolicy,
+): Response {
   return new Response(null, {
     status: 204,
-    headers: corsHeaders(origin, allowHeaders),
+    headers: corsHeaders(origin, allowHeaders, policy),
   });
 }
 
@@ -46,8 +68,9 @@ export function jsonSuccess(
   data: unknown,
   origin?: string,
   allowHeaders?: string[],
+  policy?: CorsPolicy,
 ): Response {
-  const headers = corsHeaders(origin, allowHeaders);
+  const headers = corsHeaders(origin, allowHeaders, policy);
   headers.set("Content-Type", "application/json");
 
   return new Response(JSON.stringify(data), { status: 200, headers });
@@ -58,8 +81,9 @@ export function jsonError(
   status: number,
   origin?: string,
   allowHeaders?: string[],
+  policy?: CorsPolicy,
 ): Response {
-  const headers = corsHeaders(origin, allowHeaders);
+  const headers = corsHeaders(origin, allowHeaders, policy);
   headers.set("Content-Type", "application/json");
 
   return new Response(JSON.stringify({ error: message }), { status, headers });

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -38,17 +38,19 @@ import type {
   UploadResult,
 } from "../shared/types.js";
 import {
+  type CorsPolicy,
+  corsHeaders,
   corsResponse,
   jsonError,
   jsonSuccess,
   parseOptionalTimestamp,
   sanitizeFilename,
   statusCodeForDownloadError,
-  corsHeaders,
 } from "./http.js";
 
 export { uploadFormFields };
 export type { StorageProvider, R2Config } from "../shared/types.js";
+export type { CorsPolicy } from "./http.js";
 
 export type R2ConfigInput = {
   accountId?: string;
@@ -78,8 +80,7 @@ const resolveR2Config = (input?: R2ConfigInput): R2Config | null => {
     accessKeyId:
       input?.accessKeyId ?? readEnv(REQUIRED_R2_ENV_VARS.accessKeyId),
     secretAccessKey:
-      input?.secretAccessKey ??
-      readEnv(REQUIRED_R2_ENV_VARS.secretAccessKey),
+      input?.secretAccessKey ?? readEnv(REQUIRED_R2_ENV_VARS.secretAccessKey),
     bucketName: input?.bucketName ?? readEnv(REQUIRED_R2_ENV_VARS.bucketName),
     jurisdiction:
       input?.jurisdiction ?? readEnv(OPTIONAL_R2_ENV_VARS.jurisdiction),
@@ -126,13 +127,22 @@ const normalizeOptionalHeaderName = (value?: string) => {
 const getOrigin = (request: Request) =>
   request.headers.get("Origin") ?? undefined;
 
+const isCorsOriginAllowed = (
+  origin: string | undefined,
+  policy: CorsPolicy | undefined,
+) =>
+  origin === undefined ||
+  policy === undefined ||
+  policy.allowedOrigins.includes(origin);
+
 const withCors = (
   response: Response,
   origin?: string,
   allowHeaders?: string[],
+  policy?: CorsPolicy,
 ) => {
   const headers = new Headers(response.headers);
-  const cors = corsHeaders(origin, allowHeaders);
+  const cors = corsHeaders(origin, allowHeaders, policy);
   for (const [key, value] of cors.entries()) {
     headers.set(key, value);
   }
@@ -154,6 +164,8 @@ const resolveUploadProvider = (
 export interface RegisterRoutesOptions {
   /** Prefix for HTTP routes, defaults to "/files". */
   pathPrefix?: string;
+  /** Optional exact CORS policy. Requests from other browser origins receive 403. */
+  cors?: CorsPolicy;
   /** Require accessKey for downloads (via checkDownloadRequest hook). */
   requireAccessKey?: boolean;
   /**
@@ -248,6 +260,7 @@ export function registerRoutes(
 ) {
   const {
     pathPrefix = DEFAULT_PATH_PREFIX,
+    cors,
     requireAccessKey = false,
     passwordQueryParam = "password",
     passwordHeader = "x-download-password",
@@ -282,7 +295,9 @@ export function registerRoutes(
       method: "OPTIONS",
       handler: httpActionGeneric(async (_ctx, request) => {
         const origin = getOrigin(request);
-        return corsResponse(origin);
+        if (!isCorsOriginAllowed(origin, cors))
+          return new Response(null, { status: 403 });
+        return corsResponse(origin, undefined, cors);
       }),
     });
 
@@ -291,26 +306,42 @@ export function registerRoutes(
       method: "POST",
       handler: httpActionGeneric(async (ctx, request) => {
         const origin = getOrigin(request);
+        if (!isCorsOriginAllowed(origin, cors))
+          return new Response(null, { status: 403 });
         const contentType = request.headers.get("Content-Type") ?? "";
         if (!contentType.includes("multipart/form-data")) {
           return jsonError(
             "Content-Type must be multipart/form-data",
             415,
             origin,
+            undefined,
+            cors,
           );
         }
 
         const formData = await request.formData();
         const file = formData.get(uploadFormFields.file);
         if (!(file instanceof Blob)) {
-          return jsonError("Missing or invalid 'file' field", 400, origin);
+          return jsonError(
+            "Missing or invalid 'file' field",
+            400,
+            origin,
+            undefined,
+            cors,
+          );
         }
 
         const expiresAt = parseOptionalTimestamp(
           formData.get(uploadFormFields.expiresAt),
         );
         if (expiresAt === "invalid") {
-          return jsonError("'expiresAt' must be a number or null", 400, origin);
+          return jsonError(
+            "'expiresAt' must be a number or null",
+            400,
+            origin,
+            undefined,
+            cors,
+          );
         }
 
         const provider = resolveUploadProvider(
@@ -328,7 +359,7 @@ export function registerRoutes(
 
         // If hook returns a Response, wrap it with CORS headers
         if (hookResult instanceof Response) {
-          return withCors(hookResult, origin);
+          return withCors(hookResult, origin, undefined, cors);
         }
 
         if (!hookResult || typeof hookResult !== "object") {
@@ -336,6 +367,8 @@ export function registerRoutes(
             "checkUploadRequest must return accessKeys",
             500,
             origin,
+            undefined,
+            cors,
           );
         }
 
@@ -345,6 +378,8 @@ export function registerRoutes(
             "checkUploadRequest must return accessKeys",
             500,
             origin,
+            undefined,
+            cors,
           );
         }
 
@@ -359,6 +394,8 @@ export function registerRoutes(
                 : "R2 configuration missing.",
               500,
               origin,
+              undefined,
+              cors,
             );
           }
         }
@@ -380,7 +417,7 @@ export function registerRoutes(
         });
 
         if (!uploadResponse.ok) {
-          return jsonError("File upload failed", 502, origin);
+          return jsonError("File upload failed", 502, origin, undefined, cors);
         }
 
         let storageId = presetStorageId ?? null;
@@ -392,7 +429,13 @@ export function registerRoutes(
         }
 
         if (!storageId) {
-          return jsonError("Upload did not return storageId", 502, origin);
+          return jsonError(
+            "Upload did not return storageId",
+            502,
+            origin,
+            undefined,
+            cors,
+          );
         }
 
         const metadata = {
@@ -422,11 +465,11 @@ export function registerRoutes(
           });
 
           if (hookResult instanceof Response) {
-            return withCors(hookResult, origin);
+            return withCors(hookResult, origin, undefined, cors);
           }
         }
 
-        return jsonSuccess(result, origin);
+        return jsonSuccess(result, origin, undefined, cors);
       }),
     });
   }
@@ -437,7 +480,9 @@ export function registerRoutes(
       method: "OPTIONS",
       handler: httpActionGeneric(async (_ctx, request) => {
         const origin = getOrigin(request);
-        return corsResponse(origin, downloadCorsAllowHeaders);
+        if (!isCorsOriginAllowed(origin, cors))
+          return new Response(null, { status: 403 });
+        return corsResponse(origin, downloadCorsAllowHeaders, cors);
       }),
     });
 
@@ -446,6 +491,8 @@ export function registerRoutes(
       method: "GET",
       handler: httpActionGeneric(async (ctx, request) => {
         const origin = getOrigin(request);
+        if (!isCorsOriginAllowed(origin, cors))
+          return new Response(null, { status: 403 });
         const url = new URL(request.url);
         const downloadToken = url.searchParams.get("token");
         if (!downloadToken) {
@@ -454,6 +501,7 @@ export function registerRoutes(
             400,
             origin,
             downloadCorsAllowHeaders,
+            cors,
           );
         }
 
@@ -476,7 +524,7 @@ export function registerRoutes(
             request,
           });
           if (result instanceof Response) {
-            return withCors(result, origin, downloadCorsAllowHeaders);
+            return withCors(result, origin, downloadCorsAllowHeaders, cors);
           }
           // If hook returns { accessKey }, use it
           if (result && typeof result === "object" && "accessKey" in result) {
@@ -490,6 +538,7 @@ export function registerRoutes(
             401,
             origin,
             downloadCorsAllowHeaders,
+            cors,
           );
         }
 
@@ -509,6 +558,7 @@ export function registerRoutes(
             statusCodeForDownloadError(result.status),
             origin,
             downloadCorsAllowHeaders,
+            cors,
           );
         }
 
@@ -519,11 +569,12 @@ export function registerRoutes(
             404,
             origin,
             downloadCorsAllowHeaders,
+            cors,
           );
         }
 
         const filename = sanitizeFilename(url.searchParams.get("filename"));
-        const headers = corsHeaders(origin, downloadCorsAllowHeaders);
+        const headers = corsHeaders(origin, downloadCorsAllowHeaders, cors);
         headers.set("Cache-Control", "no-store");
         headers.set(
           "Content-Disposition",


### PR DESCRIPTION
HTTP upload and download routes always reflected browser origins and enabled credentials. Consumers could not apply a strict origin policy.

This adds an optional exact CORS policy to `registerRoutes`. Unknown browser origins receive `403`, callers control the fixed allowed-header list and credentials setting, and non-browser requests continue to work. Existing behavior remains unchanged when the option is omitted.

## Verification

- `npm run test` (152 tests passed)
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run verify:dist-esm`
- No package release or publish was performed.

Model/harness: GPT-5.6 Sol in the Codex app, file-pr skill.